### PR TITLE
Support earlier non-utf8 Python versions

### DIFF
--- a/wiktionary_translation_extractor.py
+++ b/wiktionary_translation_extractor.py
@@ -126,7 +126,7 @@ def decode_term(arguments: List[str]) -> Translation:
 
 translations = defaultdict(list)
 
-with open(sys.argv[1]) as in_file:
+with open(sys.argv[1], encoding="utf-8") as in_file:
     page_title = None
     recording = False
     group = None


### PR DESCRIPTION
Although I am not very sure, it seems that in Python 3.8 or something, the preferred default encoding for Windows is changed to utf-8, but earlier version not.